### PR TITLE
Little optimizations with substantial gains

### DIFF
--- a/pyfesom2/load_mesh_data.py
+++ b/pyfesom2/load_mesh_data.py
@@ -293,8 +293,9 @@ class fesom_mesh(object):
         self.x2, self.y2 = scalar_r2g(
             self.alpha, self.beta, self.gamma, self.x2, self.y2
         )
+
         d = self.x2[self.elem].max(axis=1) - self.x2[self.elem].min(axis=1)
-        self.no_cyclic_elem = [i for (i, val) in enumerate(d) if val < 100]
+        self.no_cyclic_elem = np.argwhere(d < 100).ravel()
 
         with open(self.aux3dfile) as f:
             self.nlev = int(next(f))

--- a/pyfesom2/pfplot.py
+++ b/pyfesom2/pfplot.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of pyfesom2
-# Original code by Dmitry Sidorenko, Nikolay Koldunov, 
+# Original code by Dmitry Sidorenko, Nikolay Koldunov,
 # Qiang Wang, Sergey Danilov and Patrick Scholz
 #
 
@@ -170,7 +170,8 @@ def pfplot():
         depth=float(args.depth),
         how="mean",
         ncfile=None,
-        compute=True,
+        compute=True
+    )
 
     fig = plot(
         mesh=mesh,

--- a/pyfesom2/ut.py
+++ b/pyfesom2/ut.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of pyfesom2
-# Original code by Dmitry Sidorenko, Nikolay Koldunov, Lukrecia Stulic, 
+# Original code by Dmitry Sidorenko, Nikolay Koldunov, Lukrecia Stulic,
 # Qiang Wang, Sergey Danilov and Patrick Scholz
 #
 
@@ -83,8 +83,8 @@ def scalar_r2g(al, be, ga, rlon, rlat):
     yg = rotate_matrix[1, 0] * xr + rotate_matrix[1, 1] * yr + rotate_matrix[1, 2] * zr
     zg = (
         rotate_matrix[2, 0] * xr + rotate_matrix[2, 1] * yr + rotate_matrix[2, 2] * zr
-    )  
-    
+    )
+
     # Geographical coordinates:
     lat = np.arcsin(zg)
     lon = np.arctan2(yg, xg)
@@ -287,7 +287,7 @@ def tunnel_fast1d(latvar, lonvar, lonlat):
         lonvar : ndarray
             1d array with lons
         lonlat : ndarray
-            2d array with the shape of [2, number_of_point], 
+            2d array with the shape of [2, number_of_point],
             that contain coordinates of the points
 
     Returns:
@@ -632,7 +632,7 @@ def cut_region(mesh, box):
     elem_no_nan : array
         elements that belong to the region defined by `box`.
     no_nan_triangles: array
-        boolean array of element size with True for elements 
+        boolean array of element size with True for elements
         that belong to the `box`.
     """
     x_on_triangles = mesh.x2[mesh.elem]
@@ -696,6 +696,5 @@ def get_cmap(cmap=None):
 def get_no_cyclic(mesh, elem_no_nan):
     """Compute non cyclic elements of the mesh."""
     d = mesh.x2[elem_no_nan].max(axis=1) - mesh.x2[elem_no_nan].min(axis=1)
-    no_cyclic_elem = [i for (i, val) in enumerate(d) if val < 100]
-
-    return no_cyclic_elem
+    no_cyclic_elem = np.argwhere(d < 100)
+    return no_cyclic_elem.ravel()

--- a/pyfesom2/ut.py
+++ b/pyfesom2/ut.py
@@ -14,7 +14,6 @@ import matplotlib.pylab as plt
 import numpy as np
 import pkg_resources
 import shapely
-import xarray as xr
 from cmocean import cm as cmo
 
 try:
@@ -617,7 +616,7 @@ def set_standard_attrs(da):
 
 def cut_region(mesh, box):
     """
-    Cut region from the mesh.
+    Return mesh elements (triangles) and their indices corresponding to a bounding box.
 
     Parameters
     ----------
@@ -635,26 +634,20 @@ def cut_region(mesh, box):
         boolean array of element size with True for elements
         that belong to the `box`.
     """
-    x_on_triangles = mesh.x2[mesh.elem]
-    y_on_triangles = mesh.y2[mesh.elem]
-
     left, right, down, up = box
 
     selection = (
-        (x_on_triangles >= left)
-        & (x_on_triangles <= right)
-        & (y_on_triangles >= down)
-        & (y_on_triangles <= up)
+        (mesh.x2 >= left)
+        & (mesh.x2 <= right)
+        & (mesh.y2 >= down)
+        & (mesh.y2 <= up)
     )
-    #     indd = np.where((mesh.x2>=left) & (mesh.x2<=right) & (mesh.y2>=down) & (mesh.y2<=up))
-    # vvv = ((dd>=0) & (xx>=7.5) & (xx<=8.2) & (yy>=54) & (yy<=54.5))
-    mask = selection.mean(axis=1)
 
-    mask[mask != 1] = np.nan
+    elem_selection = selection[mesh.elem]
 
-    no_nan_triangles = np.invert(np.isnan(mask))
+    no_nan_triangles = np.all(elem_selection, axis=1)
 
-    elem_no_nan = mesh.elem[no_nan_triangles, :]
+    elem_no_nan = mesh.elem[no_nan_triangles]
 
     return elem_no_nan, no_nan_triangles
 


### PR DESCRIPTION
- [x] Optimize function [get_no_cyclic](https://github.com/FESOM/pyfesom2/blob/2b06d07ad7698d7dca9130ad0881c83f28365e46/pyfesom2/ut.py#L696). Replace non vectorized python loop with vectorized numpy argwhere function. This gives about 9x(on my machine ~9s to ~1s) performance gain for AO1km mesh. More gain for smaller mesh sizes.
- [x] Optimize function [cut_region](https://github.com/FESOM/pyfesom2/blob/2b06d07ad7698d7dca9130ad0881c83f28365e46/pyfesom2/ut.py#L618). Performance gain about 2X-4+X depending on box size in AO1km mesh and uses less memory. Performance and memory gains are due to using less array comparisons by selecting directly on nodes and using selection bool array for selecting elements.
- [x] An oops bug, [missing parenthesis](https://github.com/FESOM/pyfesom2/blob/2b06d07ad7698d7dca9130ad0881c83f28365e46/pyfesom2/pfplot.py#L173) that crept in from a clean up fdec079.