### PR TITLE
Allows xmoc_data to return xarray objects

### DIFF
--- a/pyfesom2/diagnostics.py
+++ b/pyfesom2/diagnostics.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of pyfesom2
-# Original code by Dmitry Sidorenko, Nikolay Koldunov, 
+# Original code by Dmitry Sidorenko, Nikolay Koldunov,
 # Qiang Wang, Sergey Danilov and Patrick Scholz
 #
 
@@ -361,6 +361,7 @@ def xmoc_data(
     nlevels=None,
     face_x=None,
     face_y=None,
+    returnXArray=False,
 ):
     """ Compute moc for selected region.
 
@@ -387,13 +388,18 @@ def xmoc_data(
         x coordinates of centers of elements, size elem2d. If None, will be computed.
     face_y: numpy array
         y coordinates of centers of elements, size elem2d. If None, will be computed.
+    returnXArray : bool
+        Whether or not to return an XArray
 
     Returns:
     --------
-    lats: numpy array
-        latitude bins
-    moc_masked: numpy array
-       masked array with moc values.
+    tuple or xarray.DataArray
+
+    As tuple:
+        lats: numpy array
+            latitude bins
+        moc_masked: numpy array
+           masked array with moc values.
 
     """
 
@@ -449,5 +455,6 @@ def xmoc_data(
         moc_final = moc_masked
     else:
         moc_final = moc_proper_order
-
+    if returnXArray:
+        return xr.DataArray(data=moc_final, coords=[("latitude", lats), ("depth", mesh.zlev),])
     return lats, moc_final

--- a/tests/test_diagnostics.py
+++ b/tests/test_diagnostics.py
@@ -251,3 +251,10 @@ def test_xmoc_data():
     assert moc.mean() == pytest.approx(2.471874164570943)
     assert moc.max() == pytest.approx(25.358106934063304)
     assert moc.min() == pytest.approx(-35.02300625098337)
+
+    # with xarray output
+    data = get_data(data_path, "w", [1948], mesh, how="mean", compute=True)
+    moc_da = xmoc_data(mesh, data, nlats=30, returnXArray=True)
+    assert moc_da.mean() == pytest.approx(2.471874164570943)
+    assert moc_da.max() == pytest.approx(25.358106934063304)
+    assert moc_da.min() == pytest.approx(-35.02300625098337)


### PR DESCRIPTION
This PR allows the `xmoc_data` diagnostic to return an Xarray Dataset object
rather than a tuple of lats, data. To do so, you need to set:

```
amoc_ds = pf.xmoc_data(mesh, data, returnXArray=True)
```
