### PR TITLE
test support for python 3.9 and discontinue testing on soon-to-be EOL python 3.6 on CI.

### DIFF
--- a/.github/workflows/pyfesom2_onPR.yml
+++ b/.github/workflows/pyfesom2_onPR.yml
@@ -20,7 +20,7 @@ jobs:
       fail-fast: false
       matrix:
         os: ["ubuntu-latest", "macos-latest", "windows-latest"]
-        python-version: ["3.6", "3.7", "3.8"]
+        python-version: ["3.7", "3.8", "3.9"]
     steps:
       - uses: actions/checkout@v2
       - uses: conda-incubator/setup-miniconda@v2


### PR DESCRIPTION
Add and test support for python 3.9 and discontinue testing on [soon-to-be EOL](https://endoflife.date/python) python 3.6 on CI.