### PR TITLE
Feat/ollie ci

### DIFF
--- a/.github/workflows/pyfesom2_onollie.yml
+++ b/.github/workflows/pyfesom2_onollie.yml
@@ -5,7 +5,7 @@ on: [push]
 
 jobs:
   example-1:
-    name: Ex1 (ollie ${{ matrix.module }})
+    name: ollie ${{ matrix.module }}
     runs-on: hpc_awi_ollie
     strategy:
       fail-fast: false
@@ -15,7 +15,7 @@ jobs:
             - python3/3.6.5_intel2019
             - python3/3.7.10_intel2021
             - python3/3.7.7_intel2020
-            - python3/3.7.7_intel2020u2(default)
+            - python3/3.7.7_intel2020u2
     steps:
       - uses: actions/checkout@v2
       - name: Run Test ${{ matrix.module }}
@@ -26,4 +26,28 @@ jobs:
             pip install --user -e .
             pip install --user pytest
             pytest
+  miniconda:
+    name: ollie miniconda installation
+    runs-on: hpc_awi_ollie
+    steps:
+      - uses: actions/checkout@v2
+      - name: Setup Miniconda
+        uses: conda-incubator/setup-miniconda@v2.1.1
+        with:
+            auto-update-conda: true
+            activate-environment: pyfesom2
+            environment-file: ci/requirements-py37.yml
+            channels: conda-forge
+      - name: Conda info
+        shell: bash -l {0}
+        run: conda info
+      - name: Conda list
+        shell: bash -l {0}
+        run: conda list
+      - name: Install
+        shell: bash -l {0}
+        run: pip install -e .
+      - name: Test
+        shell: bash -l {0}
+        run: pytest
 

--- a/.github/workflows/pyfesom2_onollie.yml
+++ b/.github/workflows/pyfesom2_onollie.yml
@@ -31,6 +31,10 @@ jobs:
     runs-on: hpc_awi_ollie
     env:
         CONDA: ${{ github.workspace }}
+        PATH: "/home/ollie/abtci/miniconda/bin:/home/ollie/abtci/miniconda/condabin:/usr/lib64/qt-3.3/bin:/cm/local/apps/environment-modules/4.0.0/bin:/usr/local/bin:/usr/bin:/usr/local/sbin:/usr/sbin:/sbin:/usr/sbin:/cm/local/apps/environment-modules/current/bin:/opt/munge/default/bin:/global/opt/slurm/default/bin:/global/AWIsoft/bin:/home/ollie/abtci/bin:/global/AWIsoft/bin:/home/ollie/abtci/bin"
+        TMPDIR: "/work/ollie/tmp"
+        TMP: "/work/ollie/tmp"
+        WORK: "/work/ollie/abtci"
     steps:
       - uses: actions/checkout@v2
       - name: Setup Miniconda

--- a/.github/workflows/pyfesom2_onollie.yml
+++ b/.github/workflows/pyfesom2_onollie.yml
@@ -25,17 +25,11 @@ jobs:
             - python3/3.5-intelbeta
     steps:
       - uses: actions/checkout@v2
-      - name: load ollie ${{ matrix.module }}
-        shell: bash -l {0}
-        run: module load ${{ matrix.module }}
-      - name: Install
+      - name: Run Test ${{ matrix.module }}
         shell: bash -l {0}
         run: |
+            module load ${{ matrix.module }}
             module list
             pip install -e .
-      - name: Test
-        shell: bash -l {0}
-        run: |
-            module list
             pytest
 

--- a/.github/workflows/pyfesom2_onollie.yml
+++ b/.github/workflows/pyfesom2_onollie.yml
@@ -5,7 +5,7 @@ on: [push]
 
 jobs:
   example-1:
-    name: Ex1 (ollie: ${{module}})
+    name: Ex1 (ollie: ${{ matrix.module }})
     runs-on: hpc_awi_ollie
     strategy:
       fail-fast: false
@@ -25,9 +25,9 @@ jobs:
             - python3/3.5-intelbeta
     steps:
       - uses: actions/checkout@v2
-      - name: load ollie ${{module}}
+      - name: load ollie ${{ matrix.module }}
         shell: bash -l {0}
-        run: module load ${{module}}
+        run: module load ${{ matrix.module }}
       - name: Install
         shell: bash -l {0}
         run: |

--- a/.github/workflows/pyfesom2_onollie.yml
+++ b/.github/workflows/pyfesom2_onollie.yml
@@ -4,33 +4,33 @@ name: pyfesom2 ollie test
 on: [push]
 
 jobs:
-  example-1:
-    name: ollie ${{ matrix.module }}
-    runs-on: hpc_awi_ollie
-    strategy:
-      fail-fast: false
-      matrix:
-        module:
-            - python3/3.6.3-intel2018
-            - python3/3.6.5_intel2019
-            - python3/3.7.10_intel2021
-            - python3/3.7.7_intel2020
-            - python3/3.7.7_intel2020u2
-    steps:
-      - uses: actions/checkout@v2
-      - name: Run Test ${{ matrix.module }}
-        shell: bash -l {0}
-        run: |
-            module load ${{ matrix.module }}
-            module list
-            pip install --user -e .
-            pip install --user pytest
-            pytest
+    #  example-1:
+    #    name: ollie ${{ matrix.module }}
+    #    runs-on: hpc_awi_ollie
+    #    strategy:
+    #      fail-fast: false
+    #      matrix:
+    #        module:
+    #            - python3/3.6.3-intel2018
+    #            - python3/3.6.5_intel2019
+    #            - python3/3.7.10_intel2021
+    #            - python3/3.7.7_intel2020
+    #            - python3/3.7.7_intel2020u2
+    #    steps:
+    #      - uses: actions/checkout@v2
+    #      - name: Run Test ${{ matrix.module }}
+    #        shell: bash -l {0}
+    #        run: |
+    #            module load ${{ matrix.module }}
+    #            module list
+    #            pip install --user -e .
+    #            pip install --user pytest
+    #            pytest
   miniconda:
     name: ollie miniconda installation
     runs-on: hpc_awi_ollie
     env:
-        CONDA: github.workspace
+        CONDA: ${{ github.workspace }}
     steps:
       - uses: actions/checkout@v2
       - name: Setup Miniconda

--- a/.github/workflows/pyfesom2_onollie.yml
+++ b/.github/workflows/pyfesom2_onollie.yml
@@ -29,11 +29,10 @@ jobs:
   miniconda:
     name: ollie miniconda installation
     runs-on: hpc_awi_ollie
+    env:
+        CONDA: github.workspace
     steps:
       - uses: actions/checkout@v2
-      - name: Set CONDA variable
-        shell: bash -l {0}
-        run: export CONDA=$PWD
       - name: Setup Miniconda
         uses: conda-incubator/setup-miniconda@v2.1.1
         with:

--- a/.github/workflows/pyfesom2_onollie.yml
+++ b/.github/workflows/pyfesom2_onollie.yml
@@ -30,7 +30,6 @@ jobs:
     name: ollie miniconda installation
     runs-on: hpc_awi_ollie
     env:
-        CONDA: ${{ github.workspace }}
         PATH: "/home/ollie/abtci/miniconda/bin:/home/ollie/abtci/miniconda/condabin:/usr/lib64/qt-3.3/bin:/cm/local/apps/environment-modules/4.0.0/bin:/usr/local/bin:/usr/bin:/usr/local/sbin:/usr/sbin:/sbin:/usr/sbin:/cm/local/apps/environment-modules/current/bin:/opt/munge/default/bin:/global/opt/slurm/default/bin:/global/AWIsoft/bin:/home/ollie/abtci/bin:/global/AWIsoft/bin:/home/ollie/abtci/bin"
         TMPDIR: "/work/ollie/tmp"
         TMP: "/work/ollie/tmp"

--- a/.github/workflows/pyfesom2_onollie.yml
+++ b/.github/workflows/pyfesom2_onollie.yml
@@ -5,7 +5,7 @@ on: [push]
 
 jobs:
   example-1:
-    name: Ex1 (ollie: {module})
+    name: Ex1 (ollie: ${{module}})
     runs-on: hpc_awi_ollie
     strategy:
       fail-fast: false
@@ -25,9 +25,9 @@ jobs:
             - python3/3.5-intelbeta
     steps:
       - uses: actions/checkout@v2
-      - name: load ollie {model} module
+      - name: load ollie ${{module}}
         shell: bash -l {0}
-        run: module load {module}
+        run: module load ${{module}}
       - name: Install
         shell: bash -l {0}
         run: |

--- a/.github/workflows/pyfesom2_onollie.yml
+++ b/.github/workflows/pyfesom2_onollie.yml
@@ -5,7 +5,7 @@ on: [push]
 
 jobs:
   example-1:
-    name: Ex1 (ollie: ${{ matrix.module }})
+    name: Ex1 (ollie ${{ matrix.module }})
     runs-on: hpc_awi_ollie
     strategy:
       fail-fast: false

--- a/.github/workflows/pyfesom2_onollie.yml
+++ b/.github/workflows/pyfesom2_onollie.yml
@@ -11,18 +11,11 @@ jobs:
       fail-fast: false
       matrix:
         module:
-            - python/2.7.14-intel2018(default)
-            - python/2.7.14-intel2018_no_ld_library_path
             - python3/3.6.3-intel2018
             - python3/3.6.5_intel2019
+            - python3/3.7.10_intel2021
             - python3/3.7.7_intel2020
             - python3/3.7.7_intel2020u2(default)
-            - python3/3.7.10_intel2021
-            - anaconda2/4.0.0
-            - python/2.7-intel2017.0.035
-            - python/2.7.10-intelbeta
-            - python3/3.5-intel2017
-            - python3/3.5-intelbeta
     steps:
       - uses: actions/checkout@v2
       - name: Run Test ${{ matrix.module }}
@@ -31,5 +24,6 @@ jobs:
             module load ${{ matrix.module }}
             module list
             pip install --user -e .
+            pip install --user pytest
             pytest
 

--- a/.github/workflows/pyfesom2_onollie.yml
+++ b/.github/workflows/pyfesom2_onollie.yml
@@ -31,6 +31,9 @@ jobs:
     runs-on: hpc_awi_ollie
     steps:
       - uses: actions/checkout@v2
+      - name: Set CONDA variable
+        shell: bash -l {0}
+        run: export CONDA=$PWD
       - name: Setup Miniconda
         uses: conda-incubator/setup-miniconda@v2.1.1
         with:

--- a/.github/workflows/pyfesom2_onollie.yml
+++ b/.github/workflows/pyfesom2_onollie.yml
@@ -1,0 +1,41 @@
+name: pyfesom2 ollie test
+# Controls when the action will run. Triggers the workflow on push or pull request.
+
+on: [push]
+
+jobs:
+  example-1:
+    name: Ex1 (ollie: {module})
+    runs-on: hpc_awi_ollie
+    strategy:
+      fail-fast: false
+      matrix:
+        module:
+            - python/2.7.14-intel2018(default)
+            - python/2.7.14-intel2018_no_ld_library_path
+            - python3/3.6.3-intel2018
+            - python3/3.6.5_intel2019
+            - python3/3.7.7_intel2020
+            - python3/3.7.7_intel2020u2(default)
+            - python3/3.7.10_intel2021
+            - anaconda2/4.0.0
+            - python/2.7-intel2017.0.035
+            - python/2.7.10-intelbeta
+            - python3/3.5-intel2017
+            - python3/3.5-intelbeta
+    steps:
+      - uses: actions/checkout@v2
+      - name: load ollie {model} module
+        shell: bash -l {0}
+        run: module load {module}
+      - name: Install
+        shell: bash -l {0}
+        run: |
+            module list
+            pip install -e .
+      - name: Test
+        shell: bash -l {0}
+        run: |
+            module list
+            pytest
+

--- a/.github/workflows/pyfesom2_onollie.yml
+++ b/.github/workflows/pyfesom2_onollie.yml
@@ -30,6 +30,7 @@ jobs:
     name: ollie miniconda installation
     runs-on: hpc_awi_ollie
     env:
+        CONDA: "/home/ollie/abtci/miniconda"
         PATH: "/home/ollie/abtci/miniconda/bin:/home/ollie/abtci/miniconda/condabin:/usr/lib64/qt-3.3/bin:/cm/local/apps/environment-modules/4.0.0/bin:/usr/local/bin:/usr/bin:/usr/local/sbin:/usr/sbin:/sbin:/usr/sbin:/cm/local/apps/environment-modules/current/bin:/opt/munge/default/bin:/global/opt/slurm/default/bin:/global/AWIsoft/bin:/home/ollie/abtci/bin:/global/AWIsoft/bin:/home/ollie/abtci/bin"
         TMPDIR: "/work/ollie/tmp"
         TMP: "/work/ollie/tmp"

--- a/.github/workflows/pyfesom2_onollie.yml
+++ b/.github/workflows/pyfesom2_onollie.yml
@@ -30,6 +30,6 @@ jobs:
         run: |
             module load ${{ matrix.module }}
             module list
-            pip install -e .
+            pip install --user -e .
             pytest
 


### PR DESCRIPTION
First successful run of pyfesom2 test suite on ollie bare-metal :-) 🎉 🥳 

There are a few things I would still like to discuss:

* Currently, I had to setup my own miniconda environment on the test account. We could swap that out for a singularity contaner
* I need to set quite a lot of the env variables in the CI definition, it would be nice if the runner inherited the one from the shell (that doesn't seem to be possible)
* Would it make sense to containerize the runner itself?
* I still need to add the self-hosted runner to the FESOM organization, but I need to be org-owner to do that.