### PR TITLE
Use python -m instead of pytest to make sure source modifications are

### DIFF
--- a/.github/workflows/pyfesom2.yml
+++ b/.github/workflows/pyfesom2.yml
@@ -31,5 +31,5 @@ jobs:
         run: pip install -e .
       - name: Test
         shell: bash -l {0}
-        run: pytest
+        run: python -m pytest
       

--- a/.github/workflows/pyfesom2.yml
+++ b/.github/workflows/pyfesom2.yml
@@ -28,7 +28,7 @@ jobs:
           allow-softlinks: true
       - name: Install
         shell: bash -l {0}
-        run: pip install -e .
+        run: python -m pip install -e .
       - name: Test
         shell: bash -l {0}
         run: python -m pytest

--- a/.github/workflows/pyfesom2_onPR.yml
+++ b/.github/workflows/pyfesom2_onPR.yml
@@ -36,7 +36,7 @@ jobs:
           allow-softlinks: true
       - name: Install
         shell: bash -l {0}
-        run: pip install -e .
+        run: python -m pip install -e .
       - name: Test
         shell: bash -l {0}
         run: python -m pytest

--- a/.github/workflows/pyfesom2_onPR.yml
+++ b/.github/workflows/pyfesom2_onPR.yml
@@ -39,5 +39,5 @@ jobs:
         run: pip install -e .
       - name: Test
         shell: bash -l {0}
-        run: pytest
+        run: python -m pytest
 

--- a/ci/requirements-py37.yml
+++ b/ci/requirements-py37.yml
@@ -17,6 +17,8 @@ dependencies:
   - jupyter
   - ipython
   - pytest
+  - pytest-env
+  - pytest-xdist 
   - cmocean
   - zarr>=2.8.3
   - fsspec==2021.06.1

--- a/tests/test_accessor.py
+++ b/tests/test_accessor.py
@@ -13,8 +13,8 @@ def local_dataset(request):
     data_path = os.path.join(cur_dir, "data", "pi-results", "temp.fesom.*.nc")
     mesh_path = os.path.join(cur_dir, "data", "pi-grid")
     da = open_dataset(data_path, mesh_path=mesh_path)
-    #yield da
-    return da
+    yield da
+    da.close()
 
 
 # use scope=function if we want to change grid size dynamically for each test case,

--- a/tests/test_accessor.py
+++ b/tests/test_accessor.py
@@ -9,11 +9,12 @@ from pyfesom2.datasets import open_dataset
 @pytest.fixture(scope='function')
 def local_dataset(request):
     import os.path
-    cur_dir = os.path.dirname(__file__) # __file__ may be simpler and better for multi os then request.node.path  
+    cur_dir = os.path.dirname(request.node.path) # __file__ may be simpler and better for multi os then request.node.path  
     data_path = os.path.join(cur_dir, "data", "pi-results", "temp.fesom.*.nc")
     mesh_path = os.path.join(cur_dir, "data", "pi-grid")
     da = open_dataset(data_path, mesh_path=mesh_path)
-    yield da
+    #yield da
+    return da
 
 
 # use scope=function if we want to change grid size dynamically for each test case,

--- a/tests/test_accessor.py
+++ b/tests/test_accessor.py
@@ -9,7 +9,7 @@ from pyfesom2.datasets import open_dataset
 @pytest.fixture(scope='module')
 def local_dataset(request):
     import os.path
-    cur_dir = os.path.dirname(request.fspath)
+    cur_dir = os.path.dirname(__file__) # __file__ may be simpler and better for multi os then request.node.path  
     data_path = os.path.join(cur_dir, "data", "pi-results", "temp.fesom.*.nc")
     mesh_path = os.path.join(cur_dir, "data", "pi-grid")
     da = open_dataset(data_path, mesh_path=mesh_path)

--- a/tests/test_accessor.py
+++ b/tests/test_accessor.py
@@ -6,7 +6,7 @@ from pyfesom2.datasets import open_dataset
 
 
 # TODO: push this to test config conftest.py so that it is available globally
-@pytest.fixture(scope='module')
+@pytest.fixture(scope='function')
 def local_dataset(request):
     import os.path
     cur_dir = os.path.dirname(__file__) # __file__ may be simpler and better for multi os then request.node.path  

--- a/tests/test_accessor.py
+++ b/tests/test_accessor.py
@@ -13,8 +13,9 @@ def local_dataset(request):
     data_path = os.path.join(cur_dir, "data", "pi-results", "temp.fesom.*.nc")
     mesh_path = os.path.join(cur_dir, "data", "pi-grid")
     da = open_dataset(data_path, mesh_path=mesh_path)
-    yield da
+    da.load()
     da.close()
+    yield da
 
 
 # use scope=function if we want to change grid size dynamically for each test case,

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -20,7 +20,7 @@ def cmip6_grid(request):
 @pytest.fixture
 def local_dataset(request):
     import os.path
-    cur_dir = os.path.dirname(request.fspath)
+    cur_dir = os.path.dirname(__file__)
     data_path = os.path.join(cur_dir, "data", "pi-results", "*.nc")
     mesh_path = os.path.join(cur_dir, "data", "pi-grid")
     da = datasets.open_dataset(data_path, mesh_path=mesh_path)


### PR DESCRIPTION
… available for pytest. 

This will reduce CI failures when both tests and source are updated in a PR.
