### PR TITLE
fix selection of elements for the box

### DIFF
--- a/pyfesom2/transport.py
+++ b/pyfesom2/transport.py
@@ -288,7 +288,7 @@ def _ReduceMeshElementNumber(section_waypoints, mesh, section, add_extent):
     elem_box_nods = elem_no_nan[no_cyclic_elem2]
 
     # create an array containing the indices of the elements that belong to the region
-    elem_box_indices = np.arange(mesh.e2d)[no_nan_triangles]
+    elem_box_indices = np.arange(mesh.e2d)[no_nan_triangles][no_cyclic_elem2]
 
     # Compute the distance of each section coodinate to the center of each element to further reduce the amount of polygons needed
     # in case of meridional or zonal section the chosen box is already small enough to be loaded and no further elements have to be removed


### PR DESCRIPTION
Fixes #191 (hopefully :))

The selection of elements were inconsistent. First the region is cut, then from those elements removed ones that are cyclic, then the nodes are selected and then `elem_box_indices`:
```python
elem_no_nan, no_nan_triangles = cut_region(mesh, box_mesh)
no_cyclic_elem2 = get_no_cyclic(mesh, elem_no_nan)
elem_box_nods = elem_no_nan[no_cyclic_elem2]

# create an array containing the indices of the elements that belong to the region
elem_box_indices = np.arange(mesh.e2d)[no_nan_triangles]
```

However in cases when `get_no_cyclic` actually remove some triangles using only `no_nan_triangles` is inconsistent, so one should also remove cyclic elements like this:

```python
elem_box_indices = np.arange(mesh.e2d)[no_nan_triangles][no_cyclic_elem2]
```