### PR TITLE
CI: Micromamba Workflow

### DIFF
--- a/.github/workflows/pyfesom2.yml
+++ b/.github/workflows/pyfesom2.yml
@@ -37,12 +37,11 @@ jobs:
         fetch-depth: 0
 
     - name: install conda environment
-      uses: mamba-org/provision-with-micromamba@main #/v12
+      uses: mamba-org/setup-micromamba@v2
       with:
         environment-file: main/ci/requirements-py37.yml
         environment-name: pyfesom2
-        cache-env: true
-        cache-env-key: "${{runner.os}}-${{runner.arch}}-py${{env.PYTHON_VERSION}}-${{env.TODAY}}-${{hashFiles(env.CONDA_ENV_FILE)}}"
+        cache-environment-key: "${{runner.os}}-${{runner.arch}}-py${{env.PYTHON_VERSION}}-${{env.TODAY}}-${{hashFiles(env.CONDA_ENV_FILE)}}"
 
     # - name: Checkout git commit log 
     #   working-directory: pyfesom2

--- a/.github/workflows/pyfesom2_onPR.yml
+++ b/.github/workflows/pyfesom2_onPR.yml
@@ -45,12 +45,11 @@ jobs:
         fetch-depth: 0
 
     - name: install conda environment
-      uses: mamba-org/provision-with-micromamba@main #/v12
+      uses: mamba-org/setup-micromamba@v2
       with:
         environment-file: main/ci/requirements-py37.yml
         environment-name: pyfesom2
-        cache-env: true
-        cache-env-key: "${{runner.os}}-${{runner.arch}}-py${{env.PYTHON_VERSION}}-${{env.TODAY}}-${{hashFiles(env.CONDA_ENV_FILE)}}"
+        cache-envronment-key: "${{runner.os}}-${{runner.arch}}-py${{env.PYTHON_VERSION}}-${{env.TODAY}}-${{hashFiles(env.CONDA_ENV_FILE)}}"
 
     # - name: Checkout git commit log 
     #   working-directory: pyfesom2


### PR DESCRIPTION
The CI action has a depcrecation, as noted [here](https://github.com/mamba-org/provision-with-micromamba?tab=readme-ov-file#migration-to-setup-micromamba%60).

Migrated to use `mamba-org/setup-micromamba@v2` instead of `mamba-org/provision-with-micromamba` in the workflow file.
