### PR TITLE
Fix pkg_resources import on setuptools >=81 and modernize Python support

### DIFF
--- a/.github/workflows/pyfesom2.yml
+++ b/.github/workflows/pyfesom2.yml
@@ -18,7 +18,7 @@ jobs:
       fail-fast: false
       matrix:
         os: ["ubuntu-latest"]
-        python-version: ["3.9"]
+        python-version: ["3.12"]
     defaults:
       run:
         shell: bash -l {0}
@@ -47,9 +47,11 @@ jobs:
     - name: install conda environment
       uses: mamba-org/setup-micromamba@v2
       with:
-        environment-file: main/ci/requirements-py37.yml
+        environment-file: main/ci/requirements.yml
         environment-name: pyfesom2
-        cache-environment-key: "${{runner.os}}-${{runner.arch}}-py${{env.PYTHON_VERSION}}-${{env.TODAY}}-${{hashFiles(env.CONDA_ENV_FILE)}}"
+        create-args: >-
+            python=${{ matrix.python-version }}
+        cache-environment-key: "${{runner.os}}-${{runner.arch}}-py${{matrix.python-version}}-${{hashFiles('main/ci/requirements.yml')}}"
         init-shell: >-
             bash
             zsh

--- a/.github/workflows/pyfesom2_onPR.yml
+++ b/.github/workflows/pyfesom2_onPR.yml
@@ -26,7 +26,7 @@ jobs:
       fail-fast: false
       matrix:
         os: ["ubuntu-latest", "macos-latest", "windows-latest"]
-        python-version: ["3.8", "3.9", "3.10"]
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
     defaults:
       run:
         shell: bash -l {0}
@@ -56,9 +56,11 @@ jobs:
     - name: install conda environment
       uses: mamba-org/setup-micromamba@v2
       with:
-        environment-file: main/ci/requirements-py37.yml
+        environment-file: main/ci/requirements.yml
         environment-name: pyfesom2
-        cache-envronment-key: "${{runner.os}}-${{runner.arch}}-py${{env.PYTHON_VERSION}}-${{env.TODAY}}-${{hashFiles(env.CONDA_ENV_FILE)}}"
+        create-args: >-
+            python=${{ matrix.python-version }}
+        cache-envronment-key: "${{runner.os}}-${{runner.arch}}-py${{matrix.python-version}}-${{hashFiles('main/ci/requirements.yml')}}"
         init-shell: >-
             bash
             zsh

--- a/.github/workflows/pyfesom2_onPR.yml
+++ b/.github/workflows/pyfesom2_onPR.yml
@@ -60,7 +60,7 @@ jobs:
         environment-name: pyfesom2
         create-args: >-
             python=${{ matrix.python-version }}
-        cache-envronment-key: "${{runner.os}}-${{runner.arch}}-py${{matrix.python-version}}-${{hashFiles('main/ci/requirements.yml')}}"
+        cache-environment-key: "${{runner.os}}-${{runner.arch}}-py${{matrix.python-version}}-${{hashFiles('main/ci/requirements.yml')}}"
         init-shell: >-
             bash
             zsh

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -92,7 +92,7 @@ Before you submit a pull request, check that it meets these guidelines:
 1. The pull request should ideally include tests.
 2. If the pull request adds functionality, the docs should be updated. Put
    your new functionality into a function with a docstring.
-3. The pull request should work for Python 3.6 and 3.7.
+3. The pull request should work for Python 3.9 through 3.13.
 
 Tips
 ----

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,8 +3,8 @@ COPY --chown=$MAMBA_USER:$MAMBA_USER . /app
 WORKDIR /app
 # Yeah, this next one is dumb. But it seems to be a requirement either in
 # Docker or in Mamba, Paul can't tell which but this "does the trick":
-RUN sed -i 's/name: pyfesom2/name: base/g' ./ci/requirements-py37.yml
-RUN micromamba install -f ./ci/requirements-py37.yml && \
+RUN sed -i 's/name: pyfesom2/name: base/g' ./ci/requirements.yml
+RUN micromamba install -f ./ci/requirements.yml && \
   micromamba clean --all --yes
 ARG MAMBA_DOCKERFILE_ACTIVATE=1
 RUN pip install .

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ The easiest way is to install latest stable version from `conda-forge`:
 Development Installation
 ------------------------
 If you plan to change the code inside the package, you have to install it in "development" mode. For this you would also need a working `conda`. The short guide how to install it can be found for [Linux/Mac](https://github.com/koldunovn/python_for_geosciences/blob/master/README.md#getting-started-for-linuxmac) and [Windows](https://github.com/koldunovn/python_for_geosciences/blob/master/README.md#getting-started-for-windows).
-After you install `conda` (python 3.7 environment is recomendes), clone the source code:
+After you install `conda` (python 3.12 environment is recommended), clone the source code:
 
 
     git clone https://github.com/FESOM/pyfesom2.git
@@ -33,7 +33,7 @@ After you install `conda` (python 3.7 environment is recomendes), clone the sour
 
 Create pyfesom2 environment by:
 
-    conda env create -f ./pyfesom2/ci/requirements-py37.yml
+    conda env create -f ./pyfesom2/ci/requirements.yml
 
 
 Activate the environment

--- a/ci/requirements.yml
+++ b/ci/requirements.yml
@@ -2,7 +2,6 @@ name: pyfesom2
 channels:
   - conda-forge
 dependencies:
-  - python<=3.9
   - pandas
   - numpy>=1.16
   - netCDF4
@@ -10,7 +9,7 @@ dependencies:
   - pyresample
   - seawater
   - numba
-  - scipy<=1.9
+  - scipy
   - cartopy
   - matplotlib!=3.3.1
   - shapely
@@ -19,7 +18,7 @@ dependencies:
   - pytest
   - cmocean
   - zarr>=2.8.3
-  - fsspec==2021.06.1
+  - fsspec
   - requests
   - aiohttp
   - dask

--- a/ci/requirements.yml
+++ b/ci/requirements.yml
@@ -26,3 +26,6 @@ dependencies:
   - pyproj
   - pymap3d
   - tqdm
+  - pip
+  - pip:
+      - pytest-github-actions-annotate-failures

--- a/ci/requirements_doc.yml
+++ b/ci/requirements_doc.yml
@@ -1,6 +1,6 @@
 name: pyfesom-docs
 dependencies:
-  - python=3.7
+  - python=3.12
   - pip
   - numba
   - pip:

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -15,13 +15,13 @@ The easiest way is to install latest stable version from `conda-forge`::
 Development Installation
 ************************
 
-If you want to use the latest version of the code, or just plan to change the code inside the package, you have to install it in "development" mode. After you install `conda` (python 3.7 environment is recomended), clone the source code::
+If you want to use the latest version of the code, or just plan to change the code inside the package, you have to install it in "development" mode. After you install `conda` (python 3.12 environment is recommended), clone the source code::
 
     git clone https://github.com/FESOM/pyfesom2.git
 
 Create pyfesom2 environment by::
 
-    conda env create -f ./pyfesom2/ci/requirements-py37.yml
+    conda env create -f ./pyfesom2/ci/requirements.yml
     
 Activate the environment::
 

--- a/pyfesom2/datasets.py
+++ b/pyfesom2/datasets.py
@@ -288,7 +288,7 @@ def fesom_like(spatial_size: int, spatial_extent: Tuple[float, float, float, flo
     other_dims = {}
     if times is not None:
         if isinstance(times, int):
-            other_dims['time'] = pd.date_range('2010-01-01', freq='M', periods=times)
+            other_dims['time'] = pd.date_range('2010-01-01', freq='ME', periods=times)
         else:
             other_dims['time'] = times
 

--- a/pyfesom2/load_mesh_data.py
+++ b/pyfesom2/load_mesh_data.py
@@ -244,7 +244,7 @@ class fesom_mesh(object):
     def read2d(self):
         file_content = pd.read_csv(
             self.nod2dfile,
-            delim_whitespace=True,
+            sep=r"\s+",
             skiprows=1,
             names=["node_number", "x", "y", "flag"],
         )
@@ -255,7 +255,7 @@ class fesom_mesh(object):
 
         file_content = pd.read_csv(
             self.elm2dfile,
-            delim_whitespace=True,
+            sep=r"\s+",
             skiprows=1,
             names=["first_elem", "second_elem", "third_elem"],
         )

--- a/pyfesom2/ut.py
+++ b/pyfesom2/ut.py
@@ -9,11 +9,11 @@ import json
 import logging
 import math as mt
 from collections import OrderedDict
+from importlib.resources import files
 
 import matplotlib as mpl
 import matplotlib.pylab as plt
 import numpy as np
-import pkg_resources
 import shapely
 from cmocean import cm as cmo
 
@@ -618,21 +618,15 @@ def get_mask(mesh, region):
         mask = np.hstack((ind_EB1[0], ind_EB2[0]))
 
     elif region in MOCBasins:
-        filename = pkg_resources.resource_filename(
-            __name__, "geojson/MOCBasins.geojson"
-        )
+        filename = str(files(__package__).joinpath("geojson/MOCBasins.geojson"))
         mask = mask_from_file(filename, region, mesh)
 
     elif region in NinoRegions:
-        filename = pkg_resources.resource_filename(
-            __name__, "geojson/NinoRegions.geojson"
-        )
+        filename = str(files(__package__).joinpath("geojson/NinoRegions.geojson"))
         mask = mask_from_file(filename, region, mesh)
 
     elif region in oceanBasins:
-        filename = pkg_resources.resource_filename(
-            __name__, "geojson/oceanBasins.geojson"
-        )
+        filename = str(files(__package__).joinpath("geojson/oceanBasins.geojson"))
         mask = mask_from_file(filename, region, mesh)
 
     else:

--- a/setup.py
+++ b/setup.py
@@ -47,9 +47,11 @@ setup(
         "License :: OSI Approved :: MIT License",
         "Natural Language :: English",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.6",
-        "Programming Language :: Python :: 3.7",
-        "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.10",
+        "Programming Language :: Python :: 3.11",
+        "Programming Language :: Python :: 3.12",
+        "Programming Language :: Python :: 3.13",
     ],
     entry_points={
         "console_scripts": [

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -55,7 +55,7 @@ def test_fesom_like():
     assert len(ds.nod2) == ncells
     assert len(ds.time) == ntimes
     # check if we can pass datetime arrays
-    times = pd.date_range('2001-01-01', freq='M', periods=ntimes)
+    times = pd.date_range('2001-01-01', freq='ME', periods=ntimes)
     ds = datasets.fesom_like(ncells, times=times)
     assert len(ds.time) == len(times)
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,11 +1,5 @@
 [tox]
-envlist = py34, py35, py36
-
-[travis]
-python =
-    3.6: py36
-    3.5: py35
-    3.4: py34
+envlist = py39, py310, py311, py312, py313
 
 ; [testenv:flake8]
 ; basepython = python


### PR DESCRIPTION
## Summary
- Replaces `pkg_resources` (removed in setuptools 81) with stdlib `importlib.resources.files` in `pyfesom2/ut.py`. Resolves the `ModuleNotFoundError: No module named 'pkg_resources'` reported in #236 on Python 3.12 + setuptools 82.0.1.
- Modernizes Python version support to 3.9-3.13: extends CI matrix, drops obsolete python<=3.9 / scipy<=1.9 / fsspec==2021.06.1 pins in the CI env file, renames `ci/requirements-py37.yml` -> `ci/requirements.yml`, and updates Dockerfile/README/docs/setup.py/tox.ini/CONTRIBUTING accordingly.

CI previously could not have caught #236 because the env file pinned `python<=3.9` regardless of the `matrix.python-version` value, so all jobs effectively ran on Python 3.9 (where `pkg_resources` still ships).

Split into two commits so the bug fix can be cherry-picked independently of the modernization sweep.

Fixes #236

## Test plan
- [x] CI green across 3.9-3.13 on ubuntu/macos/windows
- [x] `python -c "import pyfesom2"` succeeds with setuptools >=81
- [x] `get_mask` works for `MOCBasins`, `NinoRegions`, `oceanBasins` regions
- [x] Docker build works against renamed `ci/requirements.yml`