### PR TITLE
Silence seawater deprecation

### DIFF
--- a/.github/workflows/pyfesom2_onPR.yml
+++ b/.github/workflows/pyfesom2_onPR.yml
@@ -58,7 +58,7 @@ jobs:
       with:
         environment-file: main/ci/requirements-py37.yml
         environment-name: pyfesom2
-        cache-envronment-key: "${{runner.os}}-${{runner.arch}}-py${{env.PYTHON_VERSION}}-${{env.TODAY}}-${{hashFiles(env.CONDA_ENV_FILE)}}"
+        cache-environment-key: "${{runner.os}}-${{runner.arch}}-py${{env.PYTHON_VERSION}}-${{env.TODAY}}-${{hashFiles(env.CONDA_ENV_FILE)}}"
         init-shell: >-
             bash
             zsh

--- a/pyfesom2/climatology.py
+++ b/pyfesom2/climatology.py
@@ -8,10 +8,43 @@
 # Add seasonal climatology
 ################################################################################
 import os
+import warnings
 
 import numpy as np
 import scipy as sc
-import seawater as sw
+
+# =============================================================================
+# WARNING: EOS-80 vs TEOS-10
+# -----------------------------------------------------------------------------
+# This module deliberately uses the (deprecated, unmaintained) `seawater`
+# library, which implements the EOS-80 equation of state. The successor
+# library `gsw` implements TEOS-10, which is the *current* international
+# standard (since 2010) for seawater thermodynamics.
+#
+# We have NOT migrated to gsw on purpose:
+#
+#   * EOS-80 takes Practical Salinity (PSS-78, unitless) as input.
+#   * TEOS-10 takes Absolute Salinity (g/kg) as input, which differs from
+#     Practical Salinity by a *regionally varying* composition anomaly that
+#     gsw retrieves from a bundled lon/lat/depth atlas (`gsw.SA_from_SP`).
+#   * Climatology inputs here are practical salinity from PHC / WOA, so a
+#     literal swap would silently change the numbers and break reproducibility
+#     against legacy pyfesom2 output.
+#
+# A proper TEOS-10 migration must (1) plumb lon/lat through to compute SA,
+# (2) decide whether to use SR (gsw.SR_from_SP) as a global-mean shortcut,
+# and (3) accept that potential temperatures will differ slightly from the
+# EOS-80 reference. Until that scientific decision is made, we keep EOS-80
+# and just silence the deprecation noise.
+# =============================================================================
+with warnings.catch_warnings():
+    warnings.filterwarnings(
+        "ignore",
+        message=".*seawater library is deprecated.*",
+        category=UserWarning,
+    )
+    import seawater as sw  # noqa: E402
+
 from netCDF4 import Dataset
 from numpy import nanmean
 


### PR DESCRIPTION
## Summary
The `seawater` library prints a `UserWarning: The seawater library is deprecated! Please use gsw instead.` on every `pyfesom2` import. This PR silences that warning at the only site that imports it (`pyfesom2/climatology.py`) and adds a prominent block comment explaining why a migration to `gsw` is not happening at this time.

### Why not migrate to gsw?
- `seawater.ptmp` expects Practical Salinity (PSS-78). `gsw.pt0_from_t` expects Absolute Salinity (g/kg).
- `gsw.SA_from_SP(SP, p, lon, lat)` does a regionally varying lookup against a bundled atlas — a literal swap would silently change the numerics.
- Climatology inputs here (PHC / WOA) are practical salinity, so reproducibility against legacy pyfesom2 output would break.

A real TEOS-10 migration is a scientific decision, not a mechanical refactor, and is deferred until that decision is made.

### Compatibility check
Verified that `seawater` still runs on Python 3.13 + numpy 2.4.3 in a clean container (`sw.ptmp` returns sensible values), so silencing rather than removing is safe for the foreseeable future.

## Test plan
- [x] `python -c "import pyfesom2"` no longer prints the seawater deprecation warning
- [x] ~`pyfesom2.climatology.climatology(<phc_file>)` still produces identical potential-temperature output~ Not a sensible test, nothing touches this code
- [x] CI green